### PR TITLE
Fix Xcode 16 build error in LEB128.h

### DIFF
--- a/app_unexpectedly/app_unexpectedly/DWARF/LEB128.h
+++ b/app_unexpectedly/app_unexpectedly/DWARF/LEB128.h
@@ -14,6 +14,7 @@
 #ifndef LEB128_h
 #define LEB128_h
 
+#include <stdint.h>
 #include <stdio.h>
 
 uint64_t DWRF_readULEB128(uint8_t * inBufferPtr,uint8_t ** outBufferPtr);


### PR DESCRIPTION
Example of build error:
```
In file included from /Users/nick/Developer/External/unexpectedly/app_unexpectedly/app_unexpectedly/DWARF/LEB128.c:14:
/Users/nick/Developer/External/unexpectedly/app_unexpectedly/app_unexpectedly/DWARF/LEB128.h:19:1: error: missing '#include <_types/_uint64_t.h>'; 'uint64_t' must be declared before it is used
   19 | uint64_t DWRF_readULEB128(uint8_t * inBufferPtr,uint8_t ** outBufferPtr);
      | ^
In module '_stdio' imported from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/usr/include/stdio.h:61:
In module 'DarwinFoundation' imported from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_stdio.h:69:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/_types/_uint64_t.h:31:28: note: declaration here is not visible
   31 | typedef unsigned long long uint64_t;
      |                            ^
```