### PR TITLE
Fix crash if tHeader.crashReporterKey is nil

### DIFF
--- a/app_unexpectedly/app_unexpectedly/CUIIPSTransform.m
+++ b/app_unexpectedly/app_unexpectedly/CUIIPSTransform.m
@@ -286,6 +286,9 @@
 {
     IPSIncidentHeader * tHeader=inIncident.header;
     
+    if (tHeader.crashReporterKey==nil)
+        return [NSArray array];
+    
     NSMutableArray * tMutableArray=[NSMutableArray array];
     
     NSMutableAttributedString * tMutableAttributedString=[[self attributedStringForKey:@"Process:"] mutableCopy];


### PR DESCRIPTION
Fixes a crash on launch if a data source contains a malformated log file.

Not sure exactly what about this log file causes `tHeader.crashReporterKey` to be nil, but the log file is completely unmodified from my device.
I've attached it below if interested (with an added `.txt` extension to allow uploading to GitHub):
[Antrag-2025-09-16-170337.ips.txt](https://github.com/user-attachments/files/22483148/Antrag-2025-09-16-170337.ips.txt)
