### PR TITLE
Display build number next to version in inspector

### DIFF
--- a/app_unexpectedly/app_unexpectedly/CUICrashLogHeader.h
+++ b/app_unexpectedly/app_unexpectedly/CUICrashLogHeader.h
@@ -50,6 +50,8 @@
 
     @property (readonly,copy) NSString * executableVersion;
 
+    @property (readonly, copy) NSString * buildVersion;
+
 
 
     @property (readonly,copy) NSString * responsibleProcessName;

--- a/app_unexpectedly/app_unexpectedly/CUICrashLogHeader.m
+++ b/app_unexpectedly/app_unexpectedly/CUICrashLogHeader.m
@@ -45,6 +45,8 @@
 
     @property (copy) NSString * executableVersion;
 
+    @property (copy) NSString * buildVersion;
+
 
     @property (copy) NSString * responsibleProcessName;
 
@@ -256,6 +258,8 @@
         _bundleIdentifier=tIPSHeader.bundleInfo.bundleIdentifier;
         
         _executableVersion=tIPSHeader.bundleInfo.bundleShortVersionString;
+        
+        _buildVersion=tIPSHeader.bundleInfo.bundleVersion;
         
         
         _responsibleProcessName=tIPSHeader.responsibleProcessName;

--- a/app_unexpectedly/app_unexpectedly/CUIInspectorExecutableViewController.m
+++ b/app_unexpectedly/app_unexpectedly/CUIInspectorExecutableViewController.m
@@ -91,13 +91,22 @@
     
     NSString * tVersion=tHeader.executableVersion;
     
+    NSString * tBuild=tHeader.buildVersion;
+    
     if (tVersion==nil || [tVersion isEqualToString:@"???"]==YES)
     {
         _executableVersionValue.stringValue=NSLocalizedString(@"Unknown version",@"");
     }
     else
     {
-        _executableVersionValue.stringValue=[NSString stringWithFormat:NSLocalizedString(@"Version %@",@""),tVersion];
+        NSString * buildString = @"";
+        
+        if (tBuild!=nil)
+        {
+            buildString=[NSString stringWithFormat:@" (%@)",tBuild];
+        }
+        
+        _executableVersionValue.stringValue=[NSString stringWithFormat:NSLocalizedString(@"Version %@%@",@""),tVersion,buildString];
     }
     
     NSString * tArchitectureValue=@"-";


### PR DESCRIPTION
If contained in the crash log, the inspector will show the build number next to the executable version. If none is found, it will display the version as it always has previously.

<img width="325" height="532" alt="Example" src="https://github.com/user-attachments/assets/6a86b06d-8fe1-4550-a32a-2e5983e52080" />
